### PR TITLE
Allow for passing URL Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install react-jotform-embed
 ```
 
 ## Usage
-```javascript
+```jsx
 import JotformEmbed from 'react-jotform-embed';
 
 <JotformEmbed src="https://form.jotformeu.com/123456789" />
@@ -23,6 +23,15 @@ import JotformEmbed from 'react-jotform-embed';
 ## Props
 - src : The url of your jotform, as given in their publish section. 
 - scrolling : A boolean to allow or disallow scrolling. Scrolling is turned off by default
+
+## Notes
+
+To pre-populate forms in the field, add them as url params to your form. For example:
+
+```jdx
+let name = "John";
+<JotformEmbed src="https://form.jotformeu.com/123456789?name=John" />
+```
 
 ## Support Open-Source
 Support my work on https://github.com/sponsors/xurei

--- a/src/react-jotform-embed.js
+++ b/src/react-jotform-embed.js
@@ -29,7 +29,7 @@ export default class JotformEmbed extends React.Component {
 		const args = e.data.split(':');
 		const formId = args[2];
 		const iframe = ReactDOM.findDOMNode(this.refs.iframe);
-		if (!!iframe && (!formId || props.src.includes(formId))) {
+		if (!!iframe && (!formId || props.src.split('?')[0].endsWith(formId))) {
 			switch (args[0]) {
 				case 'scrollIntoView':
 					iframe.scrollIntoView();

--- a/src/react-jotform-embed.js
+++ b/src/react-jotform-embed.js
@@ -29,7 +29,7 @@ export default class JotformEmbed extends React.Component {
 		const args = e.data.split(':');
 		const formId = args[2];
 		const iframe = ReactDOM.findDOMNode(this.refs.iframe);
-		if (!!iframe && (!formId || props.src.endsWith(formId))) {
+		if (!!iframe && (!formId || props.src.includes(formId))) {
 			switch (args[0]) {
 				case 'scrollIntoView':
 					iframe.scrollIntoView();


### PR DESCRIPTION
In Jotform, to prefill fields in the form, the easiest way is to pass it as a URL param. However, since the code was looking for the "last" thing to be the jotform id, the code was breaking. I've changed form `endsWith` to `includes` and haven't seen any adverse effects so far. 